### PR TITLE
Downsample model I/O to 44.1k when host sample rate is higher

### DIFF
--- a/plugin/include/StemgenRT/OverlapAddProcessor.h
+++ b/plugin/include/StemgenRT/OverlapAddProcessor.h
@@ -102,6 +102,8 @@ public:
     // Dry delay priming helpers
     bool isDryDelayPrimed() const { return dryDelayPrimed_; }
     void primeDryDelayFromInput(const float* inputPointers[kNumChannels], int numSamples);
+    void setDryDelaySamples(size_t delaySamples);
+    size_t getDryDelaySamples() const { return dryDelaySamples_; }
 
     // === Chunk boundary crossfade state ===
 
@@ -141,6 +143,7 @@ private:
 
     // Dry delay line for underrun fallback
     std::array<std::vector<float>, kNumChannels> dryDelayLine_;
+    size_t dryDelaySamples_{static_cast<size_t>(kOutputChunkSize)};
     size_t dryDelayWritePos_{0};
     size_t dryDelayReadPos_{0};
     bool dryDelayPrimed_{false};

--- a/test/source/RealtimeStemSanityTest.cpp
+++ b/test/source/RealtimeStemSanityTest.cpp
@@ -8,14 +8,13 @@
 namespace audio_plugin_test {
 namespace {
 
-constexpr double kSampleRate = 44100.0;
 constexpr int kBlockSize = 128;
 constexpr int kTotalChannels = 12;  // 2 input + 10 output (5 buses * 2ch)
 
 constexpr float kPi = 3.14159265358979323846f;
 
-float sineAtSample(int64_t sampleIndex, float freqHz, float amplitude) {
-  const float t = static_cast<float>(sampleIndex) / static_cast<float>(kSampleRate);
+float sineAtSample(int64_t sampleIndex, float freqHz, float amplitude, double sampleRate) {
+  const float t = static_cast<float>(sampleIndex) / static_cast<float>(sampleRate);
   return amplitude * std::sin(2.0f * kPi * freqHz * t);
 }
 
@@ -24,6 +23,7 @@ float sineAtSample(int64_t sampleIndex, float freqHz, float amplitude) {
 // Real-time paced sanity check: with enough wall-clock time for the inference thread
 // to keep up, the 4 stem buses should not all be identical (dry fallback signature).
 TEST(RealtimeStemSanityTest, DISABLED_StemsAreNotAllIdenticalWhenRealtimePaced) {
+  constexpr double kSampleRate = 44100.0;
   audio_plugin::AudioPluginAudioProcessor processor;
   processor.prepareToPlay(kSampleRate, kBlockSize);
 
@@ -47,12 +47,12 @@ TEST(RealtimeStemSanityTest, DISABLED_StemsAreNotAllIdenticalWhenRealtimePaced) 
     auto inputBus = processor.getBusBuffer(buffer, true /* isInput */, 0);
     for (int i = 0; i < buffer.getNumSamples(); ++i) {
       const int64_t si = sampleIndex + i;
-      const float l = sineAtSample(si, 55.0f, 0.30f) +
-                      sineAtSample(si, 220.0f, 0.25f) +
-                      sineAtSample(si, 880.0f, 0.20f);
-      const float r = sineAtSample(si, 65.0f, 0.30f) +
-                      sineAtSample(si, 330.0f, 0.25f) +
-                      sineAtSample(si, 1320.0f, 0.20f);
+      const float l = sineAtSample(si, 55.0f, 0.30f, kSampleRate) +
+                      sineAtSample(si, 220.0f, 0.25f, kSampleRate) +
+                      sineAtSample(si, 880.0f, 0.20f, kSampleRate);
+      const float r = sineAtSample(si, 65.0f, 0.30f, kSampleRate) +
+                      sineAtSample(si, 330.0f, 0.25f, kSampleRate) +
+                      sineAtSample(si, 1320.0f, 0.20f, kSampleRate);
       inputBus.setSample(0, i, l);
       inputBus.setSample(1, i, r);
     }
@@ -97,5 +97,74 @@ TEST(RealtimeStemSanityTest, DISABLED_StemsAreNotAllIdenticalWhenRealtimePaced) 
   processor.releaseResources();
 }
 
-}  // namespace audio_plugin_test
+TEST(RealtimeStemSanityTest, DISABLED_StemsAreNotAllIdenticalWhenRealtimePacedAt96k) {
+  constexpr double kSampleRate = 96000.0;
+  audio_plugin::AudioPluginAudioProcessor processor;
+  processor.prepareToPlay(kSampleRate, kBlockSize);
 
+  if (processor.getLatencySamples() <= 0) {
+    GTEST_SKIP() << "Model not loaded; skipping real-time paced stem sanity check";
+  }
+
+  juce::MidiBuffer midiBuffer;
+
+  constexpr int kWarmupBlocks = 40;
+  constexpr int kMeasureBlocks = 80;
+
+  int64_t sampleIndex = 0;
+  float maxAbsStemDiff = 0.0f;
+
+  for (int b = 0; b < (kWarmupBlocks + kMeasureBlocks); ++b) {
+    juce::AudioBuffer<float> buffer(kTotalChannels, kBlockSize);
+    buffer.clear();
+
+    auto inputBus = processor.getBusBuffer(buffer, true /* isInput */, 0);
+    for (int i = 0; i < buffer.getNumSamples(); ++i) {
+      const int64_t si = sampleIndex + i;
+      const float l = sineAtSample(si, 55.0f, 0.30f, kSampleRate) +
+                      sineAtSample(si, 220.0f, 0.25f, kSampleRate) +
+                      sineAtSample(si, 880.0f, 0.20f, kSampleRate);
+      const float r = sineAtSample(si, 65.0f, 0.30f, kSampleRate) +
+                      sineAtSample(si, 330.0f, 0.25f, kSampleRate) +
+                      sineAtSample(si, 1320.0f, 0.20f, kSampleRate);
+      inputBus.setSample(0, i, l);
+      inputBus.setSample(1, i, r);
+    }
+
+    processor.processBlock(buffer, midiBuffer);
+
+    if (b >= kWarmupBlocks) {
+      const int numOutputBuses = processor.getBusCount(false /* isInput */);
+      ASSERT_GE(numOutputBuses, 5) << "Expected 5 output buses (Main + 4 stems)";
+
+      auto drumsBus = processor.getBusBuffer(buffer, false /* isInput */, 1);
+      auto bassBus = processor.getBusBuffer(buffer, false /* isInput */, 2);
+      auto otherBus = processor.getBusBuffer(buffer, false /* isInput */, 3);
+      auto vocalsBus = processor.getBusBuffer(buffer, false /* isInput */, 4);
+
+      for (int i = 0; i < buffer.getNumSamples(); ++i) {
+        for (int ch = 0; ch < 2; ++ch) {
+          const float d = drumsBus.getSample(ch, i);
+          const float b0 = bassBus.getSample(ch, i);
+          const float o = otherBus.getSample(ch, i);
+          const float v = vocalsBus.getSample(ch, i);
+
+          maxAbsStemDiff = std::max(maxAbsStemDiff, std::abs(d - b0));
+          maxAbsStemDiff = std::max(maxAbsStemDiff, std::abs(d - o));
+          maxAbsStemDiff = std::max(maxAbsStemDiff, std::abs(d - v));
+        }
+      }
+    }
+
+    sampleIndex += buffer.getNumSamples();
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  EXPECT_GT(maxAbsStemDiff, 1.0e-3f)
+      << "Stem buses appear identical (likely underrun fallback only); maxAbsStemDiff="
+      << maxAbsStemDiff;
+
+  processor.releaseResources();
+}
+
+}  // namespace audio_plugin_test


### PR DESCRIPTION
## Summary
- add a host-rate adaptation path in `processBlock` for `host sample rate > 44.1kHz` so model input is downsampled to 44.1k and model output is upsampled back to host rate
- keep the existing direct path for host rates at or below 44.1kHz
- update latency reporting and dry-delay alignment to account for sample-rate adaptation startup offset
- make dry-delay length configurable in `OverlapAddProcessor` so fallback stays aligned with dynamic latency
- extend tests for high-rate runtime coverage and add a disabled 96k realtime stem sanity variant

## Testing
- `cmake --build build`
- `./build/test/AudioPluginTest --gtest_filter='AudioProcessorTest.PrepareToPlayWithVariousSampleRates:ProcessBlockTest.ProcessBlockHandlesHostRateAboveModelRate'`
- `./build/test/AudioPluginTest --gtest_filter='AudioProcessorTest.*:ProcessBlockTest.*'`
- `ctest --preset default --output-on-failure`
- `cmake -S . -B build-release && cmake --build build-release`
- `./scripts/install-plugins.sh`
- `./scripts/install-plugins.sh --release`
